### PR TITLE
Add fullscreen support

### DIFF
--- a/main.cc
+++ b/main.cc
@@ -44,6 +44,11 @@ int main(int argc, char *argv[]) {
                                    qtr("Clear settings"));
 
   parser.addOption(clearSettings);
+
+  QCommandLineOption fullScreen(QStringList() << "f" << "full-screen",
+                                  qtr("Start Full Screen"));
+  parser.addOption(fullScreen);
+
   parser.process(a);
 
   if (parser.isSet(clearSettings)) {
@@ -54,6 +59,9 @@ int main(int argc, char *argv[]) {
   QString url_str = parser.value(url);
   MainWindow w(0, QUrl(url_str));
 
+  if (parser.isSet(fullScreen)) {
+    w.ToggleFullScreen();
+  }
   w.show();
   return a.exec();
 }

--- a/mainwindow.h
+++ b/mainwindow.h
@@ -37,9 +37,12 @@ class MainWindow : public QMainWindow {
   void SetUrl(const QUrl &url);
   // Overriden from QMainWindow
   void keyPressEvent(QKeyEvent *event);
+
+ public slots:
+  void ToggleFullScreen();
+
  private slots:
   void OpenUrlDialog();
-  void ToggleFullScreen();
 
  private:
   Ui::MainWindow *ui_;


### PR DESCRIPTION
This starts OpenIVI in full screen mode by default. It still allows the user to
press escape to exit back to normal mode.  We might also want a mode that
disables this for production use.
