### PR TITLE
Set organization for settings saving

### DIFF
--- a/main.cc
+++ b/main.cc
@@ -28,6 +28,7 @@ QString qtr(const char *key) {
 
 int main(int argc, char *argv[]) {
   QApplication a(argc, argv);
+  QApplication::setOrganizationName("OpenIVI");
   QApplication::setApplicationName("openivi");
 
   QCommandLineParser parser;


### PR DESCRIPTION
So that config doesn't get stored under the directory "Unknown Organization".
