### PR TITLE
main.cc: Fix full screen

### DIFF
--- a/main.cc
+++ b/main.cc
@@ -61,10 +61,11 @@ int main(int argc, char *argv[]) {
   QString url_str = parser.value(url);
   MainWindow w(0, QUrl(url_str));
 
+  w.show();
+
   if (parser.isSet(fullScreen)) {
     w.ToggleFullScreen();
   }
-  w.show();
   return a.exec();
 }
 /* vim: set expandtab tabstop=2 shiftwidth=2: */


### PR DESCRIPTION
Show the webview and after that expand to full
screen to fix the bug with blinking white screen
which affects openivi-html5 while running with
argument -f on top of Wayland and Weston from
Automotive Grade Linux (AGL).

Signed-off-by: Leon Anavi <leon.anavi@konsulko.com>